### PR TITLE
feat: Add time spine model to fix dbt parsing error

### DIFF
--- a/dbt_postgres_demo/models/date_spine.sql
+++ b/dbt_postgres_demo/models/date_spine.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        materialized = 'table',
+    )
+}}
+with
+base_dates as (
+    {{
+        dbt.date_spine(
+            'day',
+            "DATE('2000-01-01')",
+            "DATE('2030-01-01')"
+        )
+    }}
+),
+final as (
+    select
+        cast(date_day as date) as date_day
+    from base_dates
+)
+select *
+from final

--- a/dbt_postgres_demo/models/schema.yml
+++ b/dbt_postgres_demo/models/schema.yml
@@ -32,3 +32,11 @@ models:
           - not_null
       - name: notes
         description: "notes of the debt"
+  - name: date_spine
+    description: "This table is a time spine model with daily granularity."
+    time_spine:
+      standard_granularity_column: date_day
+    columns:
+      - name: date_day
+        description: "The base date column for daily granularity."
+        granularity: day


### PR DESCRIPTION
This commit introduces a time spine model to the dbt project. The semantic layer (MetricFlow) requires a time spine model with a granularity of DAY or smaller, and this change adds a `date_spine` model to fulfill that requirement.

The new `date_spine.sql` model generates a daily series of dates. The `schema.yml` file is updated to configure this model as the time spine for the project.

This change resolves the following dbt parsing error: "The semantic layer requires a time spine model with granularity DAY or smaller in the project, but none was found."