### PR TITLE
Fix: Correct derived metric expression in metrics.yml

### DIFF
--- a/dbt_postgres_demo/models/semantic_models/metrics.yml
+++ b/dbt_postgres_demo/models/semantic_models/metrics.yml
@@ -20,5 +20,7 @@ metrics:
     description: "Average revenue per order"
     type: derived
     type_params:
-      expr: "{{ total_revenue_metric  }} / NULLIF({{ order_count_metric  }}, 0)"
-      metrics: [total_revenue_metric, order_count_metric ]
+      expr: "total_revenue_metric / NULLIF(order_count_metric, 0)"
+      metrics:
+        - total_revenue_metric
+        - order_count_metric


### PR DESCRIPTION
The derived metric `avg_revenue_metric` was using Jinja templating in its `expr`, which caused `metricflow` to generate an invalid SQL query. This commit removes the unnecessary Jinja brackets to ensure the query is generated correctly.